### PR TITLE
Character replacement

### DIFF
--- a/src/main/java/com/eddarmitage/slugger/CharacterReplacer.java
+++ b/src/main/java/com/eddarmitage/slugger/CharacterReplacer.java
@@ -1,22 +1,42 @@
 package com.eddarmitage.slugger;
 
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
 
 class CharacterReplacer {
 
     private final Locale locale;
     private final boolean preserveCase;
+    private final Map<Character, String> replacements;
 
     CharacterReplacer(Locale locale, boolean preserveCase) {
         this.locale = locale;
         this.preserveCase = preserveCase;
+        this.replacements = new HashMap<>();
+    }
+
+    private CharacterReplacer(Locale locale, boolean preserveCase, Map<Character, String> replacements) {
+        this.locale = locale;
+        this.preserveCase = preserveCase;
+        this.replacements = replacements;
     }
 
     public CharacterReplacer withCasePreserved() {
         return new CharacterReplacer(locale, true);
     }
 
+    public CharacterReplacer withReplacement(Character c, String replacement) {
+        HashMap<Character, String> updatedReplacements = new HashMap<>(replacements);
+        updatedReplacements.put(c, replacement);
+        return new CharacterReplacer(locale, preserveCase, updatedReplacements);
+    }
+
     public String replaceCharacters(String input) {
+        for (Entry<Character, String> replacement : replacements.entrySet()) {
+            input = input.replaceAll(replacement.getKey().toString(), replacement.getValue());
+        }
         return changeCase(input);
     }
 

--- a/src/main/java/com/eddarmitage/slugger/CharacterReplacer.java
+++ b/src/main/java/com/eddarmitage/slugger/CharacterReplacer.java
@@ -1,0 +1,26 @@
+package com.eddarmitage.slugger;
+
+import java.util.Locale;
+
+class CharacterReplacer {
+
+    private final Locale locale;
+    private final boolean preserveCase;
+
+    CharacterReplacer(Locale locale, boolean preserveCase) {
+        this.locale = locale;
+        this.preserveCase = preserveCase;
+    }
+
+    public CharacterReplacer withCasePreserved() {
+        return new CharacterReplacer(locale, true);
+    }
+
+    public String replaceCharacters(String input) {
+        return changeCase(input);
+    }
+
+    private String changeCase(String word) {
+        return preserveCase ? word : word.toLowerCase(locale);
+    }
+}

--- a/src/main/java/com/eddarmitage/slugger/Slugger.java
+++ b/src/main/java/com/eddarmitage/slugger/Slugger.java
@@ -142,6 +142,17 @@ public class Slugger {
     }
 
     /**
+     * Returns a version of this slugger that replaces the specified character
+     *
+     * @param c  the character to be replaced
+     * @param replacement  the String to replace the character with
+     * @return a {@code Slugger} based on this slugger, but with an additional character replacement
+     */
+    public Slugger withReplacement(Character c, String replacement) {
+        return new Slugger(wordSplitter, targetLength, enforceHardLimit, separator, characterReplacer.withReplacement(c, replacement));
+    }
+
+    /**
      * Generates a slug-version of the provided input.
      * <p>
      * The output will nto contain any characters that require escaping for use

--- a/src/test/java/com/eddarmitage/slugger/CharacterReplacerTest.java
+++ b/src/test/java/com/eddarmitage/slugger/CharacterReplacerTest.java
@@ -1,0 +1,36 @@
+package com.eddarmitage.slugger;
+
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CharacterReplacerTest {
+
+    @Test
+    public void testCharactersConvertedToLowercase_whenPreserveCaseDisabled() {
+        CharacterReplacer characterReplacer = new CharacterReplacer(Locale.ENGLISH, false);
+        assertThat(characterReplacer.replaceCharacters("PsYcHiC SpIeS FrOm cHiNa tRy tO StEaL YoUr mInDs eLaTiOn"))
+                .isEqualTo("psychic spies from china try to steal your minds elation");
+    }
+
+    @Test
+    public void testCaseIsPreserved_whenPreserveCaseEnabled() {
+        CharacterReplacer characterReplacer = new CharacterReplacer(Locale.ENGLISH, true);
+        assertThat(characterReplacer.replaceCharacters("SoMeTiMeS I FeEl lIkE I DoNt hAvE A PaRtNeR"))
+                .isEqualTo("SoMeTiMeS I FeEl lIkE I DoNt hAvE A PaRtNeR");
+    }
+
+    @Test
+    public void testEnforcedCaseMutator_setsConstructorFlagCorrectly() {
+        CharacterReplacer toLowerCaseReplacer = new CharacterReplacer(Locale.ENGLISH, false);
+        CharacterReplacer preservedCaseReplacer = new CharacterReplacer(Locale.ENGLISH, true);
+
+        String input = "CaNt sToP AdDiCtEd tO ThIs sHiNdIg";
+
+        assertThat(toLowerCaseReplacer.withCasePreserved().replaceCharacters(input))
+                .isEqualTo(preservedCaseReplacer.replaceCharacters(input));
+
+    }
+}

--- a/src/test/java/com/eddarmitage/slugger/CharacterReplacerTest.java
+++ b/src/test/java/com/eddarmitage/slugger/CharacterReplacerTest.java
@@ -31,6 +31,13 @@ public class CharacterReplacerTest {
 
         assertThat(toLowerCaseReplacer.withCasePreserved().replaceCharacters(input))
                 .isEqualTo(preservedCaseReplacer.replaceCharacters(input));
+    }
 
+    @Test
+    public void testCharactersAreReplaced_whenSpecificReplacementIsGiven() {
+        CharacterReplacer characterReplacer = new CharacterReplacer(Locale.ENGLISH, false).withReplacement('ä', "a");
+
+        assertThat(characterReplacer.replaceCharacters("ständing in line to see the show tonight änd theres ä light on"))
+                .isEqualTo("standing in line to see the show tonight and theres a light on");
     }
 }

--- a/src/test/java/com/eddarmitage/slugger/SluggerTest.java
+++ b/src/test/java/com/eddarmitage/slugger/SluggerTest.java
@@ -9,7 +9,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class SluggerTest {
 
-
     @Test
     public void testNullInput_causesNullPointerException() {
         assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> Slugger.create().sluggify(null))

--- a/src/test/java/com/eddarmitage/slugger/bdd/StepDefinitions.java
+++ b/src/test/java/com/eddarmitage/slugger/bdd/StepDefinitions.java
@@ -2,6 +2,7 @@ package com.eddarmitage.slugger.bdd;
 
 import com.eddarmitage.slugger.Slugger;
 import com.eddarmitage.slugger.splitting.WordSplitters;
+import cucumber.api.PendingException;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
@@ -45,14 +46,19 @@ public class StepDefinitions {
         slugger = slugger.withCasePreserved();
     }
 
+    @Given("^a replacement from '(.)' to \"(.+)\"$")
+    public void a_replacement(Character c, String replacement) throws Throwable {
+        slugger = slugger.withReplacement(c, replacement);
+    }
+
     @When("^the input string \"(.*)\" is sluggified$")
     public void sluffigyString(String input) {
         output = slugger.sluggify(input);
     }
 
-    @Then("^the output will not contain any spaces$")
-    public void checkOutputHasNoSpaces() {
-        assertThat(output).doesNotContain(" ");
+    @Then("^the output will not contain any '(.)' characters")
+    public void checkOutputHasNoSpaces(Character character) {
+        assertThat(output).doesNotContain(character.toString());
     }
 
     @Then("^the output will be (\\d+) characters long$")

--- a/src/test/resources/com/eddarmitage/slugger/bdd/character-replacing.feature
+++ b/src/test/resources/com/eddarmitage/slugger/bdd/character-replacing.feature
@@ -10,3 +10,9 @@ Feature: Remove characters in slugs, replacing them where appropriate
     When the input string "Hello World" is sluggified
     Then the output will contain a 'H' character
     And the output will contain a 'W' character
+
+  Scenario: Specific characters can be replaced with substitute strings
+    Given a replacement from 'u' to "oo"
+    When the input string "gu" is sluggified
+    Then the output will be 3 characters long
+    And the output will not contain any 'u' characters

--- a/src/test/resources/com/eddarmitage/slugger/bdd/word-joining.feature
+++ b/src/test/resources/com/eddarmitage/slugger/bdd/word-joining.feature
@@ -5,11 +5,11 @@ Feature: Words should be joined together correctly
 
   Scenario: By default, join words with a hyphen
     When the input string "hello world" is sluggified
-    Then the output will not contain any spaces
+    Then the output will not contain any ' ' characters
     And the output will contain a '-' character
 
   Scenario: Join words using an alternative character
     Given a separator of "_"
     When the input string "hello world" is sluggified
-    Then the output will not contain any spaces
+    Then the output will not contain any ' ' characters
     And the output will contain a '_' character

--- a/src/test/resources/com/eddarmitage/slugger/bdd/word-splitting.feature
+++ b/src/test/resources/com/eddarmitage/slugger/bdd/word-splitting.feature
@@ -8,29 +8,29 @@ Feature: Slugs should be split into words correctly
 
   Scenario: Words should be split by whitespace
     When the input string "This is a title" is sluggified
-    Then the output will not contain any spaces
+    Then the output will not contain any ' ' characters
     And the output will contain 3 '-' characters
 
   Scenario: Words are not split by camel-case by default
     When the input string "The importance of toString()" is sluggified
-    Then the output will not contain any spaces
+    Then the output will not contain any ' ' characters
     And the output will contain 3 '-' characters
 
   Scenario: Words can be split by camel-case
     Given camel case splitting is enabled
     When the input string "The importance of toString()" is sluggified
-    Then the output will not contain any spaces
+    Then the output will not contain any ' ' characters
     And the output will contain 4 '-' characters
 
   Scenario: Words can be split by underscores
     Given underscore splitting is enabled
     When the input string "Why I love snake_case conventions" is sluggified
-    Then the output will not contain any spaces
+    Then the output will not contain any ' ' characters
     And the output will contain 5 '-' characters
 
   Scenario: Word-splitters can be combined
     Given camel case splitting is enabled
     And underscore splitting is enabled
     When the input string "Why I prefer camelCase to snake_case" is sluggified
-    Then the output will not contain any spaces
+    Then the output will not contain any ' ' characters
     And the output will contain 7 '-' characters


### PR DESCRIPTION
Initial refactoring of Slugger to allow for fancier character replacement to be added in the future, such as replacing `ß` with `ss`, or transliterating `ü` to `u` or `ue` depending on the locale.