### PR TITLE
Migrate semantic release action

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -9,7 +9,9 @@ jobs:
     name: Release Slugger
     runs-on: ubuntu-latest
     steps:
-      - uses: brpaz/action-semantic-release@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Perform release
+        uses: cycjimmy/semantic-release-action@v2
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          GITHUB_URL: github.com/eddarmitage/Slugger.git

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -14,4 +14,4 @@ jobs:
       - name: Perform release
         uses: cycjimmy/semantic-release-action@v2
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.PERSONAL_ACCESS_TOKEN}}


### PR DESCRIPTION
The original semantic release action [has been deprecated][dep-notice] and recomendeds migrating to [an alternative][alternative-action] that appears to be feature-compatible.

I hadn't ever got the previous action correctly set up to create releases (I suspect because it was never checking out the repository) so have also included that change here - taken straight from the sample docs of the new action.

[dep-notice]: https://github.com/brpaz/action-semantic-release/commit/3b1dd421a78ef9e57747c159bb927c409117e97c
[alternative-action]: https://github.com/marketplace/actions/action-for-semantic-release